### PR TITLE
Check if parentNode exists before removing element.

### DIFF
--- a/dist/swiped.js
+++ b/dist/swiped.js
@@ -345,7 +345,7 @@
             }
         });
 
-        if (isRemoveNode) {
+        if (isRemoveNode && this.elem.parentNone) {
             this.elem.parentNode.removeChild(this.elem);
         }
     };


### PR DESCRIPTION
If the swipe event fires twice for a node, the first event would have
already removed the node from the parent.